### PR TITLE
Add session last-handoff command for retrieving previous session notes

### DIFF
--- a/.claude/hooks/session-start.py
+++ b/.claude/hooks/session-start.py
@@ -55,9 +55,16 @@ def main():
 
     context_parts = ["<chainlink-session-context>"]
 
+    # Get handoff notes from previous session before starting new one
+    last_handoff = run_chainlink(["session", "last-handoff"])
+
     # Auto-start session if none active
     if not has_active_session():
         run_chainlink(["session", "start"])
+
+    # Include previous session handoff notes if available
+    if last_handoff and "No previous" not in last_handoff:
+        context_parts.append(f"## Previous Session Handoff\n{last_handoff}")
 
     # Try to get session status
     session_status = run_chainlink(["session", "status"])

--- a/chainlink/src/main.rs
+++ b/chainlink/src/main.rs
@@ -341,6 +341,8 @@ enum SessionCommands {
         /// Issue ID
         id: i64,
     },
+    /// Show handoff notes from the previous session
+    LastHandoff,
 }
 
 #[derive(Subcommand)]
@@ -597,6 +599,7 @@ fn main() -> Result<()> {
                 SessionCommands::End { notes } => commands::session::end(&db, notes.as_deref()),
                 SessionCommands::Status => commands::session::status(&db),
                 SessionCommands::Work { id } => commands::session::work(&db, id),
+                SessionCommands::LastHandoff => commands::session::last_handoff(&db),
             }
         }
 


### PR DESCRIPTION
Previously, handoff notes from ended sessions were effectively lost:
- `session start` only showed them when no session was active
- `session status` didn't display previous session's notes
- The Claude hook discarded the handoff notes output

This adds a `session last-handoff` subcommand that retrieves handoff notes from the most recent ended session, making them accessible at any time. The hook now includes these notes in its context output.