### PR TITLE
Fix `chainlink init` to merge into existing `.mcp.json` instead of replacing it

### DIFF
--- a/chainlink/src/commands/init.rs
+++ b/chainlink/src/commands/init.rs
@@ -89,11 +89,11 @@ const RULE_FILES: &[(&str, &str)] = &[
 /// Returns a list of warnings (e.g. overwritten keys) for the caller to display.
 fn write_mcp_json_merged(mcp_path: &Path) -> Result<Vec<String>> {
     let embedded: serde_json::Value = serde_json::from_str(MCP_JSON)
-        .expect("embedded MCP_JSON is not valid JSON — this is a build defect");
+        .context("embedded MCP_JSON is not valid JSON — this is a build defect")?;
     let src_servers = embedded
         .get("mcpServers")
         .and_then(|v| v.as_object())
-        .expect("embedded MCP_JSON missing mcpServers object — this is a build defect");
+        .context("embedded MCP_JSON missing mcpServers object — this is a build defect")?;
 
     let mut obj = match fs::read_to_string(mcp_path) {
         Ok(raw) => {


### PR DESCRIPTION
i noticed that `chainlink init` was obliterating my existing MCPs. this PR would avoid that. Instead of overwriting, the initialization function now reads and parses the existing `.mcp.json` if it's present, then replaces only the Chainlink MCP with the new config.

i wrote a test suite to verify this, and also verified it by building and running against my own projects.

some potential shortcomings:
- `serde` isn't configured to preserve order right now, so this _will_ change the order of `.mcp.json`. i could also change the `serde` config to `preserve_order`, but that felt like a thing i should ask about before doing?
- if you ever choose to _rename_ any of the MCP server keys, that could get annoying. because a fresh `chainlink init --force` would add the new key, but no longer remove the old one. that's very doable but would require remembering this PR exists and modifying the functionality- maybe adding a list of old keys to wipe, or a list of key translations like a mini-migration system, idk

self-review to follow inline