### PR TITLE
Bugfix: Cross-compilation environments were not installed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install Rust stdlib for cross compiling
+        if: matrix.os != 'windows-latest'
+        run: rustup target add ${{ matrix.target }} 
+
       - name: Build release
         run: cargo build --release --target ${{ matrix.target }}
 


### PR DESCRIPTION
We build the macos binaries on an aarch64 machine, but with an x86_64 target. We must explicitly install the x86_64 target toolchain. Likewise, for Linux builds.