### PR TITLE
Allow multiple `--label` args to `chainlink issue list`.

### DIFF
--- a/chainlink/src/commands/archive.rs
+++ b/chainlink/src/commands/archive.rs
@@ -141,7 +141,7 @@ mod tests {
             !archived.iter().any(|i| i.id == id),
             "Issue should no longer be archived"
         );
-        let closed = db.list_issues(Some("closed"), None, None).unwrap();
+        let closed = db.list_issues(Some("closed"), &[], None).unwrap();
         assert!(
             closed.iter().any(|i| i.id == id),
             "Issue should be back in closed list"
@@ -217,8 +217,8 @@ mod tests {
         db.close_issue(id).unwrap();
         archive(&db, id).unwrap();
 
-        let open_issues = db.list_issues(Some("open"), None, None).unwrap();
-        let closed_issues = db.list_issues(Some("closed"), None, None).unwrap();
+        let open_issues = db.list_issues(Some("open"), &[], None).unwrap();
+        let closed_issues = db.list_issues(Some("closed"), &[], None).unwrap();
         assert!(!open_issues.iter().any(|i| i.id == id));
         assert!(!closed_issues.iter().any(|i| i.id == id));
     }

--- a/chainlink/src/commands/comment.rs
+++ b/chainlink/src/commands/comment.rs
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(comments[0].content, malicious);
 
         // Verify database integrity
-        let issues = db.list_issues(None, None, None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert!(!issues.is_empty());
     }
 

--- a/chainlink/src/commands/cpitd.rs
+++ b/chainlink/src/commands/cpitd.rs
@@ -117,7 +117,7 @@ fn dedup_marker(file_a: &str, file_b: &str) -> String {
 
 fn find_existing_clone_issue(db: &Database, file_a: &str, file_b: &str) -> Result<Option<i64>> {
     let marker = dedup_marker(file_a, file_b);
-    let issues = db.list_issues(Some("open"), Some("cpitd"), None)?;
+    let issues = db.list_issues(Some("open"), &["cpitd".to_string()], None)?;
     for issue in issues {
         if let Some(ref desc) = issue.description {
             if desc.contains(&marker) {
@@ -293,7 +293,7 @@ pub fn scan(
 }
 
 pub fn status(db: &Database) -> Result<()> {
-    let issues = db.list_issues(Some("open"), Some("cpitd"), None)?;
+    let issues = db.list_issues(Some("open"), &["cpitd".to_string()], None)?;
 
     if issues.is_empty() {
         println!("No open cpitd clone issues.");
@@ -308,7 +308,7 @@ pub fn status(db: &Database) -> Result<()> {
 }
 
 pub fn clear(db: &Database) -> Result<()> {
-    let issues = db.list_issues(Some("open"), Some("cpitd"), None)?;
+    let issues = db.list_issues(Some("open"), &["cpitd".to_string()], None)?;
 
     if issues.is_empty() {
         println!("No open cpitd clone issues to close.");

--- a/chainlink/src/commands/delete.rs
+++ b/chainlink/src/commands/delete.rs
@@ -221,7 +221,7 @@ mod tests {
         run_force(&db, id2).unwrap();
 
         // Only id3 should remain
-        let issues = db.list_issues(None, None, None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].id, id3);
     }

--- a/chainlink/src/commands/export.rs
+++ b/chainlink/src/commands/export.rs
@@ -67,7 +67,7 @@ fn export_issue(db: &Database, issue: &Issue) -> Result<ExportedIssue> {
 }
 
 pub fn run_json(db: &Database, output_path: Option<&str>) -> Result<()> {
-    let issues = db.list_issues(Some("all"), None, None)?;
+    let issues = db.list_issues(Some("all"), &[], None)?;
 
     let exported: Vec<ExportedIssue> = issues
         .iter()
@@ -96,7 +96,7 @@ pub fn run_json(db: &Database, output_path: Option<&str>) -> Result<()> {
 }
 
 pub fn run_markdown(db: &Database, output_path: Option<&str>) -> Result<()> {
-    let issues = db.list_issues(Some("all"), None, None)?;
+    let issues = db.list_issues(Some("all"), &[], None)?;
     let mut md = String::new();
 
     md.push_str("# Chainlink Issues Export\n\n");

--- a/chainlink/src/commands/import.rs
+++ b/chainlink/src/commands/import.rs
@@ -132,7 +132,7 @@ mod tests {
         fs::write(&import_path, json).unwrap();
         let result = run_json(&db, &import_path);
         assert!(result.is_ok());
-        let issues = db.list_issues(Some("all"), None, None).unwrap();
+        let issues = db.list_issues(Some("all"), &[], None).unwrap();
         assert_eq!(issues.len(), 1);
     }
 
@@ -146,7 +146,7 @@ mod tests {
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
         run_json(&db, &import_path).unwrap();
-        let issues = db.list_issues(Some("all"), None, None).unwrap();
+        let issues = db.list_issues(Some("all"), &[], None).unwrap();
         assert_eq!(issues.len(), 2);
     }
 
@@ -157,7 +157,7 @@ mod tests {
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
         run_json(&db, &import_path).unwrap();
-        let issues = db.list_issues(Some("closed"), None, None).unwrap();
+        let issues = db.list_issues(Some("closed"), &[], None).unwrap();
         assert_eq!(issues.len(), 1);
     }
 
@@ -170,7 +170,7 @@ mod tests {
         let import_path = dir.path().join("import.json");
         fs::write(&import_path, json).unwrap();
         run_json(&db, &import_path).unwrap();
-        let issues = db.list_issues(Some("all"), None, None).unwrap();
+        let issues = db.list_issues(Some("all"), &[], None).unwrap();
         let labels = db.get_labels(issues[0].id).unwrap();
         assert!(labels.contains(&"bug".to_string()));
     }

--- a/chainlink/src/commands/label.rs
+++ b/chainlink/src/commands/label.rs
@@ -162,7 +162,7 @@ mod tests {
         assert!(labels.contains(&malicious.to_string()));
 
         // Verify database integrity
-        let issues = db.list_issues(None, None, None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert!(!issues.is_empty());
     }
 

--- a/chainlink/src/commands/list.rs
+++ b/chainlink/src/commands/list.rs
@@ -7,10 +7,10 @@ use crate::utils::{format_issue_id, truncate};
 pub fn run_json(
     db: &Database,
     status: Option<&str>,
-    label: Option<&str>,
+    labels: &[String],
     priority: Option<&str>,
 ) -> Result<()> {
-    let issues = db.list_issues(status, label, priority)?;
+    let issues = db.list_issues(status, labels, priority)?;
     println!("{}", serde_json::to_string_pretty(&issues)?);
     Ok(())
 }
@@ -18,10 +18,10 @@ pub fn run_json(
 pub fn run(
     db: &Database,
     status: Option<&str>,
-    label: Option<&str>,
+    labels: &[String],
     priority: Option<&str>,
 ) -> Result<()> {
-    let issues = db.list_issues(status, label, priority)?;
+    let issues = db.list_issues(status, labels, priority)?;
 
     if issues.is_empty() {
         println!("No issues found.");
@@ -107,8 +107,8 @@ mod tests {
     #[test]
     fn test_run_empty() {
         let (db, _dir) = setup_test_db();
-        run(&db, None, None, None).unwrap();
-        let issues = db.list_issues(None, None, None).unwrap();
+        run(&db, None, &[], None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert!(issues.is_empty());
     }
 
@@ -119,8 +119,8 @@ mod tests {
         db.create_issue("Issue 2", None, "medium").unwrap();
         db.create_issue("Issue 3", None, "low").unwrap();
 
-        run(&db, None, None, None).unwrap();
-        let issues = db.list_issues(None, None, None).unwrap();
+        run(&db, None, &[], None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert_eq!(issues.len(), 3);
     }
 
@@ -131,11 +131,11 @@ mod tests {
         let id2 = db.create_issue("Closed issue", None, "medium").unwrap();
         db.close_issue(id2).unwrap();
 
-        let issues = db.list_issues(Some("open"), None, None).unwrap();
+        let issues = db.list_issues(Some("open"), &[], None).unwrap();
         assert!(issues.iter().any(|i| i.id == id1));
         assert!(!issues.iter().any(|i| i.id == id2));
 
-        let result = run(&db, Some("open"), None, None);
+        let result = run(&db, Some("open"), &[], None);
         assert!(result.is_ok());
     }
 
@@ -146,11 +146,11 @@ mod tests {
         let id2 = db.create_issue("Closed issue", None, "medium").unwrap();
         db.close_issue(id2).unwrap();
 
-        let issues = db.list_issues(Some("closed"), None, None).unwrap();
+        let issues = db.list_issues(Some("closed"), &[], None).unwrap();
         assert!(!issues.iter().any(|i| i.id == id1));
         assert!(issues.iter().any(|i| i.id == id2));
 
-        let result = run(&db, Some("closed"), None, None);
+        let result = run(&db, Some("closed"), &[], None);
         assert!(result.is_ok());
     }
 
@@ -161,8 +161,8 @@ mod tests {
         let id2 = db.create_issue("Closed issue", None, "medium").unwrap();
         db.close_issue(id2).unwrap();
 
-        run(&db, Some("all"), None, None).unwrap();
-        let issues = db.list_issues(Some("all"), None, None).unwrap();
+        run(&db, Some("all"), &[], None).unwrap();
+        let issues = db.list_issues(Some("all"), &[], None).unwrap();
         assert_eq!(issues.len(), 2);
         assert!(issues.iter().any(|i| i.id == id1));
         assert!(issues.iter().any(|i| i.id == id2));
@@ -176,11 +176,11 @@ mod tests {
         db.add_label(id1, "bug").unwrap();
         db.add_label(id2, "feature").unwrap();
 
-        let issues = db.list_issues(None, Some("bug"), None).unwrap();
+        let issues = db.list_issues(None, &["bug".to_string()], None).unwrap();
         assert!(issues.iter().any(|i| i.id == id1));
         assert!(!issues.iter().any(|i| i.id == id2));
 
-        let result = run(&db, None, Some("bug"), None);
+        let result = run(&db, None, &["bug".to_string()], None);
         assert!(result.is_ok());
     }
 
@@ -190,11 +190,11 @@ mod tests {
         let id1 = db.create_issue("High priority", None, "high").unwrap();
         let id2 = db.create_issue("Low priority", None, "low").unwrap();
 
-        let issues = db.list_issues(None, None, Some("high")).unwrap();
+        let issues = db.list_issues(None, &[], Some("high")).unwrap();
         assert!(issues.iter().any(|i| i.id == id1));
         assert!(!issues.iter().any(|i| i.id == id2));
 
-        let result = run(&db, None, None, Some("high"));
+        let result = run(&db, None, &[], Some("high"));
         assert!(result.is_ok());
     }
 
@@ -209,13 +209,13 @@ mod tests {
         db.add_label(id3, "feature").unwrap();
 
         let issues = db
-            .list_issues(Some("open"), Some("bug"), Some("high"))
+            .list_issues(Some("open"), &["bug".to_string()], Some("high"))
             .unwrap();
         assert!(issues.iter().any(|i| i.id == id1));
         assert!(!issues.iter().any(|i| i.id == id2));
         assert!(!issues.iter().any(|i| i.id == id3));
 
-        let result = run(&db, Some("open"), Some("bug"), Some("high"));
+        let result = run(&db, Some("open"), &["bug".to_string()], Some("high"));
         assert!(result.is_ok());
     }
 
@@ -225,7 +225,7 @@ mod tests {
         let long_title = "A".repeat(100);
         db.create_issue(&long_title, None, "medium").unwrap();
 
-        let result = run(&db, None, None, None);
+        let result = run(&db, None, &[], None);
         assert!(result.is_ok());
     }
 
@@ -235,7 +235,7 @@ mod tests {
         db.create_issue("日本語タイトル 🎉", None, "medium")
             .unwrap();
 
-        let result = run(&db, None, None, None);
+        let result = run(&db, None, &[], None);
         assert!(result.is_ok());
     }
 
@@ -244,14 +244,38 @@ mod tests {
         let (db, _dir) = setup_test_db();
         db.create_issue("Issue", None, "medium").unwrap();
 
-        run(&db, None, Some("nonexistent-label"), None).unwrap();
+        run(&db, None, &["nonexistent-label".to_string()], None).unwrap();
         let issues = db
-            .list_issues(None, Some("nonexistent-label"), None)
+            .list_issues(None, &["nonexistent-label".to_string()], None)
             .unwrap();
         assert!(
             issues.is_empty(),
             "No issues should match nonexistent label"
         );
+    }
+
+    #[test]
+    fn test_run_multi_label_and_filter() {
+        let (db, _dir) = setup_test_db();
+        let id1 = db.create_issue("Bug with feature", None, "high").unwrap();
+        let id2 = db.create_issue("Bug only", None, "medium").unwrap();
+        let id3 = db.create_issue("Feature only", None, "medium").unwrap();
+        db.add_label(id1, "bug").unwrap();
+        db.add_label(id1, "feature").unwrap();
+        db.add_label(id2, "bug").unwrap();
+        db.add_label(id3, "feature").unwrap();
+
+        // AND filter: must have both "bug" AND "feature"
+        let issues = db
+            .list_issues(None, &["bug".to_string(), "feature".to_string()], None)
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert!(issues.iter().any(|i| i.id == id1));
+        assert!(!issues.iter().any(|i| i.id == id2));
+        assert!(!issues.iter().any(|i| i.id == id3));
+
+        let result = run(&db, None, &["bug".to_string(), "feature".to_string()], None);
+        assert!(result.is_ok());
     }
 
     proptest! {
@@ -281,8 +305,8 @@ mod tests {
             db.create_issue("Match", None, &priority).unwrap();
             db.create_issue("Other", None, "low").unwrap();
 
-            run(&db, None, None, Some(&priority)).unwrap();
-            let filtered = db.list_issues(None, None, Some(&priority)).unwrap();
+            run(&db, None, &[], Some(&priority)).unwrap();
+            let filtered = db.list_issues(None, &[], Some(&priority)).unwrap();
             prop_assert!(filtered.iter().all(|i| i.priority == priority));
         }
     }

--- a/chainlink/src/commands/search.rs
+++ b/chainlink/src/commands/search.rs
@@ -178,7 +178,7 @@ mod tests {
         db.create_issue("Normal issue", None, "medium").unwrap();
 
         run(&db, "'; DROP TABLE issues; --").unwrap();
-        let issues = db.list_issues(None, None, None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert_eq!(
             issues.len(),
             1,

--- a/chainlink/src/commands/status.rs
+++ b/chainlink/src/commands/status.rs
@@ -149,12 +149,12 @@ fn append_to_changelog(path: &Path, category: &str, entry: &str) -> Result<()> {
 
 pub fn close_all(
     db: &Database,
-    label_filter: Option<&str>,
+    label_filters: &[String],
     priority_filter: Option<&str>,
     update_changelog: bool,
     chainlink_dir: &Path,
 ) -> Result<()> {
-    let issues = db.list_issues(Some("open"), label_filter, priority_filter)?;
+    let issues = db.list_issues(Some("open"), label_filters, priority_filter)?;
 
     if issues.is_empty() {
         println!("No matching open issues found.");

--- a/chainlink/src/commands/tree.rs
+++ b/chainlink/src/commands/tree.rs
@@ -43,7 +43,7 @@ fn print_tree_recursive(
 
 pub fn run(db: &Database, status_filter: Option<&str>) -> Result<()> {
     // Get all top-level issues (no parent)
-    let all_issues = db.list_issues(status_filter, None, None)?;
+    let all_issues = db.list_issues(status_filter, &[], None)?;
     let top_level: Vec<_> = all_issues
         .into_iter()
         .filter(|i| i.parent_id.is_none())
@@ -98,7 +98,7 @@ mod tests {
     fn test_run_empty() {
         let (db, _dir) = setup_test_db();
         run(&db, None).unwrap();
-        let issues = db.list_issues(None, None, None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert!(issues.is_empty());
     }
 
@@ -107,7 +107,7 @@ mod tests {
         let (db, _dir) = setup_test_db();
         let id = db.create_issue("Test issue", None, "medium").unwrap();
         run(&db, None).unwrap();
-        let issues = db.list_issues(None, None, None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].id, id);
     }
@@ -149,7 +149,7 @@ mod tests {
         let open_id = db.create_issue("Open issue", None, "medium").unwrap();
         db.close_issue(closed_id).unwrap();
         run(&db, Some("open")).unwrap();
-        let open_issues = db.list_issues(Some("open"), None, None).unwrap();
+        let open_issues = db.list_issues(Some("open"), &[], None).unwrap();
         assert_eq!(open_issues.len(), 1);
         assert_eq!(open_issues[0].id, open_id);
     }
@@ -160,7 +160,7 @@ mod tests {
         let id = db.create_issue("Issue", None, "medium").unwrap();
         db.close_issue(id).unwrap();
         run(&db, Some("closed")).unwrap();
-        let closed = db.list_issues(Some("closed"), None, None).unwrap();
+        let closed = db.list_issues(Some("closed"), &[], None).unwrap();
         assert_eq!(closed.len(), 1);
         assert_eq!(closed[0].id, id);
     }
@@ -172,7 +172,7 @@ mod tests {
         let id = db.create_issue("Closed issue", None, "medium").unwrap();
         db.close_issue(id).unwrap();
         run(&db, Some("all")).unwrap();
-        let all = db.list_issues(Some("all"), None, None).unwrap();
+        let all = db.list_issues(Some("all"), &[], None).unwrap();
         assert_eq!(all.len(), 2);
     }
 

--- a/chainlink/src/commands/update.rs
+++ b/chainlink/src/commands/update.rs
@@ -193,7 +193,7 @@ mod tests {
         assert_eq!(issue.title, malicious);
 
         // Verify database is intact
-        let issues = db.list_issues(None, None, None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         assert!(!issues.is_empty());
     }
 

--- a/chainlink/src/db/issues.rs
+++ b/chainlink/src/db/issues.rs
@@ -87,7 +87,7 @@ impl Database {
     pub fn list_issues(
         &self,
         status_filter: Option<&str>,
-        label_filter: Option<&str>,
+        label_filters: &[String],
         priority_filter: Option<&str>,
     ) -> Result<Vec<Issue>> {
         let mut sql = String::from(
@@ -96,8 +96,10 @@ impl Database {
         let mut conditions = Vec::new();
         let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
 
-        if label_filter.is_some() {
-            sql.push_str(" JOIN labels l ON i.id = l.issue_id");
+        for (idx, label) in label_filters.iter().enumerate() {
+            let alias = format!("l{}", idx);
+            sql.push_str(&format!(" JOIN labels {} ON i.id = {}.issue_id AND {}.label = ?", alias, alias, alias));
+            params_vec.push(Box::new(label.clone()));
         }
 
         if let Some(status) = status_filter {
@@ -106,11 +108,6 @@ impl Database {
                 conditions.push("i.status = ?".to_string());
                 params_vec.push(Box::new(status.to_string()));
             }
-        }
-
-        if let Some(label) = label_filter {
-            conditions.push("l.label = ?".to_string());
-            params_vec.push(Box::new(label.to_string()));
         }
 
         if let Some(priority) = priority_filter {

--- a/chainlink/src/db/issues.rs
+++ b/chainlink/src/db/issues.rs
@@ -98,7 +98,10 @@ impl Database {
 
         for (idx, label) in label_filters.iter().enumerate() {
             let alias = format!("l{}", idx);
-            sql.push_str(&format!(" JOIN labels {} ON i.id = {}.issue_id AND {}.label = ?", alias, alias, alias));
+            sql.push_str(&format!(
+                " JOIN labels {} ON i.id = {}.issue_id AND {}.label = ?",
+                alias, alias, alias
+            ));
             params_vec.push(Box::new(label.clone()));
         }
 

--- a/chainlink/src/db/proptest_tests.rs
+++ b/chainlink/src/db/proptest_tests.rs
@@ -80,7 +80,7 @@ proptest! {
         for i in 0..count {
             db.create_issue(&format!("Issue {}", i), None, "medium").unwrap();
         }
-        let issues = db.list_issues(None, None, None).unwrap();
+        let issues = db.list_issues(None, &[], None).unwrap();
         prop_assert_eq!(issues.len(), count);
     }
 
@@ -171,14 +171,14 @@ proptest! {
         }
 
         // Verify children exist
-        let issues_before = db.list_issues(None, None, None).unwrap();
+        let issues_before = db.list_issues(None, &[], None).unwrap();
         prop_assert_eq!(issues_before.len(), child_count + 1);
 
         // Delete parent
         db.delete_issue(parent_id).unwrap();
 
         // All children should be gone too
-        let issues_after = db.list_issues(None, None, None).unwrap();
+        let issues_after = db.list_issues(None, &[], None).unwrap();
         prop_assert_eq!(issues_after.len(), 0);
 
         // Verify each child is gone

--- a/chainlink/src/db/tests.rs
+++ b/chainlink/src/db/tests.rs
@@ -73,7 +73,7 @@ fn test_list_issues() {
     db.create_issue("Issue 2", None, "medium").unwrap();
     db.create_issue("Issue 3", None, "high").unwrap();
 
-    let issues = db.list_issues(None, None, None).unwrap();
+    let issues = db.list_issues(None, &[], None).unwrap();
     assert_eq!(issues.len(), 3);
 }
 
@@ -85,15 +85,15 @@ fn test_list_issues_filter_by_status() {
     let id2 = db.create_issue("To be closed", None, "medium").unwrap();
     db.close_issue(id2).unwrap();
 
-    let open_issues = db.list_issues(Some("open"), None, None).unwrap();
+    let open_issues = db.list_issues(Some("open"), &[], None).unwrap();
     assert_eq!(open_issues.len(), 1);
     assert_eq!(open_issues[0].id, id1);
 
-    let closed_issues = db.list_issues(Some("closed"), None, None).unwrap();
+    let closed_issues = db.list_issues(Some("closed"), &[], None).unwrap();
     assert_eq!(closed_issues.len(), 1);
     assert_eq!(closed_issues[0].id, id2);
 
-    let all_issues = db.list_issues(Some("all"), None, None).unwrap();
+    let all_issues = db.list_issues(Some("all"), &[], None).unwrap();
     assert_eq!(all_issues.len(), 2);
 }
 
@@ -104,7 +104,7 @@ fn test_list_issues_filter_by_priority() {
     db.create_issue("Low priority", None, "low").unwrap();
     db.create_issue("High priority", None, "high").unwrap();
 
-    let high_issues = db.list_issues(None, None, Some("high")).unwrap();
+    let high_issues = db.list_issues(None, &[], Some("high")).unwrap();
     assert_eq!(high_issues.len(), 1);
     assert_eq!(high_issues[0].priority, "high");
 }
@@ -288,7 +288,7 @@ fn test_list_issues_filter_by_label() {
     db.add_label(id1, "bug").unwrap();
     db.add_label(id2, "feature").unwrap();
 
-    let bug_issues = db.list_issues(None, Some("bug"), None).unwrap();
+    let bug_issues = db.list_issues(None, &["bug".to_string()], None).unwrap();
     assert_eq!(bug_issues.len(), 1);
     assert_eq!(bug_issues[0].id, id1);
 }
@@ -705,7 +705,7 @@ fn test_sql_injection_in_title() {
     assert_eq!(issue.title, malicious);
 
     // Database should still be intact
-    let issues = db.list_issues(None, None, None).unwrap();
+    let issues = db.list_issues(None, &[], None).unwrap();
     assert!(!issues.is_empty());
 }
 
@@ -750,7 +750,7 @@ fn test_sql_injection_in_search() {
     assert!(results.is_empty());
 
     // Database should still be intact
-    let issues = db.list_issues(None, None, None).unwrap();
+    let issues = db.list_issues(None, &[], None).unwrap();
     assert!(!issues.is_empty());
 }
 
@@ -966,7 +966,7 @@ fn test_corrupted_db_file_truncated() {
         }
         Ok(db) => {
             // If SQLite somehow recovers, verify the original data is gone
-            let issues = db.list_issues(Some("all"), None, None).unwrap();
+            let issues = db.list_issues(Some("all"), &[], None).unwrap();
             assert!(
                 issues.is_empty(),
                 "Truncated DB should not retain original data"

--- a/chainlink/src/main.rs
+++ b/chainlink/src/main.rs
@@ -205,9 +205,9 @@ enum Commands {
         /// Filter by status (open, closed, all)
         #[arg(short, long, default_value = "open")]
         status: String,
-        /// Filter by label
+        /// Filter by label (repeatable, AND logic)
         #[arg(short, long)]
-        label: Option<String>,
+        label: Vec<String>,
         /// Filter by priority
         #[arg(short, long)]
         priority: Option<String>,
@@ -256,9 +256,9 @@ enum Commands {
     /// Close all issues matching filters (shortcut for `issue close-all`)
     #[command(hide = true)]
     CloseAll {
-        /// Filter by label
+        /// Filter by label (repeatable, AND logic)
         #[arg(short, long)]
-        label: Option<String>,
+        label: Vec<String>,
         /// Filter by priority
         #[arg(short, long)]
         priority: Option<String>,
@@ -481,9 +481,9 @@ enum IssueCommands {
         /// Filter by status (open, closed, all)
         #[arg(short, long, default_value = "open")]
         status: String,
-        /// Filter by label
+        /// Filter by label (repeatable, AND logic)
         #[arg(short, long)]
-        label: Option<String>,
+        label: Vec<String>,
         /// Filter by priority
         #[arg(short, long)]
         priority: Option<String>,
@@ -527,9 +527,9 @@ enum IssueCommands {
 
     /// Close all issues matching filters
     CloseAll {
-        /// Filter by label
+        /// Filter by label (repeatable, AND logic)
         #[arg(short, long)]
-        label: Option<String>,
+        label: Vec<String>,
         /// Filter by priority
         #[arg(short, long)]
         priority: Option<String>,
@@ -1037,9 +1037,9 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
         } => {
             let db = get_db()?;
             if json {
-                commands::list::run_json(&db, Some(&status), label.as_deref(), priority.as_deref())
+                commands::list::run_json(&db, Some(&status), &label, priority.as_deref())
             } else {
-                commands::list::run(&db, Some(&status), label.as_deref(), priority.as_deref())
+                commands::list::run(&db, Some(&status), &label, priority.as_deref())
             }
         }
 
@@ -1096,7 +1096,7 @@ fn dispatch_issue(action: IssueCommands, quiet: bool, json: bool) -> Result<()> 
             let chainlink_dir = find_chainlink_dir()?;
             commands::status::close_all(
                 &db,
-                label.as_deref(),
+                &label,
                 priority.as_deref(),
                 !no_changelog,
                 &chainlink_dir,


### PR DESCRIPTION
* Multiple `--label` arguments act as multiple filters.
* Those issues with *all* such labels are listed; those with a partial set of labels are filtered out.
* Changed type signatures and tests throughout to allow a list of label strings rather than `Some` label filter.
* SQL layer constructs multiple joins.

Testing:
* Automated test cases added
* Tested manually by creating four issues:

```
issue  labels
a      X Y
b      X
c      Y
d      <none>
```

Run `chainlink issue list --label X --label Y` and get only issue `a`. using `--label X` gets a, b, Y => a, c, no label filter will show all four items.